### PR TITLE
Add email update feature

### DIFF
--- a/src/app/(profile)/profile/email/_components/EditEmail.tsx
+++ b/src/app/(profile)/profile/email/_components/EditEmail.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { InputForm } from '@/app/(profile)/profile/email/_components/InputForm'
+import { updateEmail } from '@/app/(profile)/profile/email/actions'
+import { Button } from '@/components/ui/button'
+import { Form } from '@/components/ui/form'
+import { EmailFormSchema } from '@/schemas'
+import type { EmailFormType } from '@/types'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
+interface EditEmailProps {
+        email: string | null
+}
+
+export const EditEmail = ({ email }: EditEmailProps) => {
+        const router = useRouter()
+
+        const defaultValues: EmailFormType = {
+                email: email || ''
+        }
+
+        const form = useForm<EmailFormType>({
+                resolver: zodResolver(EmailFormSchema),
+                defaultValues
+        })
+
+        const {
+                handleSubmit,
+                control,
+                formState: { isSubmitting }
+        } = form
+
+        const onSubmit = async (data: EmailFormType) => {
+                await new Promise(async (resolve) => {
+                        try {
+                                const res = await updateEmail(data)
+                                if (!res?.success) {
+                                        toast.error(res?.message || 'メールアドレスの更新に失敗しました')
+                                        resolve(res.error)
+                                        return
+                                }
+                                resolve(res.success)
+                                toast.success(res.message)
+                                router.push('/login')
+                                router.refresh()
+                        } catch (error) {
+                                // eslint-disable-next-line no-console
+                                console.error(error)
+                                resolve(error)
+                                if (error instanceof Error) {
+                                        toast.error(error.message)
+                                } else {
+                                        toast.error('メールアドレスの更新に失敗しました')
+                                }
+                        }
+                })
+        }
+
+        const onReset = () => {
+                form.reset()
+        }
+
+        return (
+                <Form {...form}>
+                        <form onSubmit={handleSubmit(onSubmit)} className='w-full space-y-8'>
+                                <h2 className='text-2xl font-bold'>メールアドレス編集</h2>
+                                <InputForm control={control} />
+                                <div className='flex justify-end space-x-4'>
+                                        <Button type='button' size='lg' variant='outline' onClick={onReset}>
+                                                リセット
+                                        </Button>
+                                        <Button type='submit' size='lg' disabled={isSubmitting}>
+                                                {isSubmitting ? '送信中...' : '更新'}
+                                        </Button>
+                                </div>
+                        </form>
+                </Form>
+        )
+}

--- a/src/app/(profile)/profile/email/_components/InputForm.tsx
+++ b/src/app/(profile)/profile/email/_components/InputForm.tsx
@@ -1,0 +1,19 @@
+import { InputElement } from '@/components/common/FormElements'
+import type { EmailFormType } from '@/types'
+import { Control } from 'react-hook-form'
+
+interface InputFormProps {
+        control: Control<EmailFormType>
+}
+
+export const InputForm = ({ control }: InputFormProps) => {
+        return (
+                <InputElement
+                        label='メールアドレス'
+                        name='email'
+                        type='email'
+                        placeholder='example@example.com'
+                        control={control}
+                />
+        )
+}

--- a/src/app/(profile)/profile/email/actions.ts
+++ b/src/app/(profile)/profile/email/actions.ts
@@ -1,0 +1,58 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/supabaseServerClient'
+import type { EmailFormType } from '@/types'
+
+export const getUserEmail = async () => {
+        try {
+                const supabase = await createClient()
+                const {
+                        data: { user }
+                } = await supabase.auth.getUser()
+
+                if (!user) {
+                        throw new Error('ユーザーが見つかりません')
+                }
+
+                return { id: user.id, email: user.email }
+        } catch (error) {
+                if (error instanceof Error) {
+                        throw new Error(error.message)
+                }
+        }
+}
+
+export const updateEmail = async (input: EmailFormType) => {
+        try {
+                const supabase = await createClient()
+                const { error } = await supabase.auth.updateUser({
+                        email: input.email
+                })
+
+                if (error) {
+                        return {
+                                success: false,
+                                message: 'メールアドレス更新に失敗しました',
+                                status: 500,
+                                error
+                        }
+                }
+
+                await supabase.auth.signOut()
+
+                return {
+                        success: true,
+                        message: 'メールアドレスを更新しました'
+                }
+        } catch (error) {
+                return {
+                        success: false,
+                        message:
+                                error instanceof Error
+                                        ? error.message
+                                        : '予期せぬエラーが発生しました',
+                        status: 500,
+                        error
+                }
+        }
+}

--- a/src/app/(profile)/profile/email/error.tsx
+++ b/src/app/(profile)/profile/email/error.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { redirect } from 'next/navigation'
+
+export default function Error({ error }: { error: Error }) {
+        // eslint-disable-next-line no-console
+        console.error(error)
+
+        return (
+                <div className='flex min-h-[calc(100vh-64px-64px)] flex-col items-center justify-center'>
+                        <h2 className='mb-4 text-2xl font-bold'>{error.message}</h2>
+                        <p className='mb-8 text-gray-600'>再度ログインしてください。</p>
+                        <Button type='button' size='lg' onClick={() => redirect('/')}>
+                                ホームへ戻る
+                        </Button>
+                </div>
+        )
+}

--- a/src/app/(profile)/profile/email/layout.tsx
+++ b/src/app/(profile)/profile/email/layout.tsx
@@ -1,0 +1,26 @@
+import { AppSidebar } from '@/components/common/AppSidebar'
+import {
+        SidebarInset,
+        SidebarProvider,
+        SidebarTrigger
+} from '@/components/ui/sidebar'
+import { cookies } from 'next/headers'
+
+export default async function Layout({
+        children
+}: {
+        children: React.ReactNode
+}) {
+        const cookieStore = await cookies()
+        const defaultOpen = cookieStore.get('sidebar_state')?.value === 'true'
+
+        return (
+                <SidebarProvider defaultOpen={defaultOpen} className='min-h-[calc(100vh-64px-64px)]'>
+                        <AppSidebar />
+                        <section className='w-full'>
+                                <SidebarTrigger />
+                                <SidebarInset>{children}</SidebarInset>
+                        </section>
+                </SidebarProvider>
+        )
+}

--- a/src/app/(profile)/profile/email/page.tsx
+++ b/src/app/(profile)/profile/email/page.tsx
@@ -1,0 +1,16 @@
+import { EditEmail } from '@/app/(profile)/profile/email/_components/EditEmail'
+import { getUserEmail } from '@/app/(profile)/profile/email/actions'
+
+export default async function Page() {
+        const user = await getUserEmail()
+
+        if (!user) {
+                throw new Error('ユーザー情報が見つかりませんでした')
+        }
+
+        return (
+                <div className='flex min-h-[calc(100vh-64px-64px-64px)] px-12 py-20'>
+                        <EditEmail email={user.email} />
+                </div>
+        )
+}

--- a/src/components/common/AppSidebar.tsx
+++ b/src/components/common/AppSidebar.tsx
@@ -13,21 +13,21 @@ import {
 
 // Menu items.
 const items = [
-	{
-		title: 'プロフィール編集',
-		url: '#',
-		icon: UserCog
-	},
-	{
-		title: 'メールアドレス編集',
-		url: '#',
-		icon: Mail
-	},
-	{
-		title: 'パスワード変更',
-		url: '#',
-		icon: KeyRound
-	}
+        {
+                title: 'プロフィール編集',
+                url: '/profile',
+                icon: UserCog
+        },
+        {
+                title: 'メールアドレス編集',
+                url: '/profile/email',
+                icon: Mail
+        },
+        {
+                title: 'パスワード変更',
+                url: '/auth/password',
+                icon: KeyRound
+        }
 ]
 
 export function AppSidebar() {

--- a/src/schemas/formSchema.ts
+++ b/src/schemas/formSchema.ts
@@ -70,9 +70,13 @@ export const SetPassWordFormSchema = SetPassWordFormFields.refine(
 )
 
 export const ProfileFormSchema = SignupFormFields.pick({
-	userName: true,
-	userNameKana: true,
-	gender: true,
-	phoneNumber: true,
-	prefecture: true
+        userName: true,
+        userNameKana: true,
+        gender: true,
+        phoneNumber: true,
+        prefecture: true
+})
+
+export const EmailFormSchema = SignupFormFields.pick({
+        email: true
 })

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,15 +1,17 @@
 import {
-	LoginFormSchema,
-	ProfileFormSchema,
-	ResetPassWordSchema,
-	SetPassWordFormSchema,
-	SignupFormSchema
+       LoginFormSchema,
+       ProfileFormSchema,
+       ResetPassWordSchema,
+       SetPassWordFormSchema,
+       SignupFormSchema,
+       EmailFormSchema
 } from '@/schemas/formSchema'
 
 export {
-	LoginFormSchema,
-	ProfileFormSchema,
-	ResetPassWordSchema,
-	SetPassWordFormSchema,
-	SignupFormSchema
+       LoginFormSchema,
+       ProfileFormSchema,
+       ResetPassWordSchema,
+       SetPassWordFormSchema,
+       SignupFormSchema,
+       EmailFormSchema
 }

--- a/src/types/formType.d.ts
+++ b/src/types/formType.d.ts
@@ -1,9 +1,10 @@
 import {
-	LoginFormSchema,
-	ProfileFormSchema,
-	ResetPassWordSchema,
-	SetPassWordFormSchema,
-	SignupFormSchema
+       LoginFormSchema,
+       ProfileFormSchema,
+       ResetPassWordSchema,
+       SetPassWordFormSchema,
+       SignupFormSchema,
+       EmailFormSchema
 } from '@/schemas'
 import { z } from 'zod'
 
@@ -12,6 +13,7 @@ export type LoginFormType = z.infer<typeof LoginFormSchema>
 export type ResetPassWordFormType = z.infer<typeof ResetPassWordSchema>
 export type SetPassWordFormType = z.infer<typeof SetPassWordFormSchema>
 export type ProfileFormType = z.infer<typeof ProfileFormSchema>
+export type EmailFormType = z.infer<typeof EmailFormSchema>
 
 export type UpdateProfileType = ProfileFormType & {
 	id: string

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,10 +1,11 @@
 import type {
-	LoginFormType,
-	ProfileFormType,
-	ResetPassWordFormType,
-	SetPassWordFormType,
-	SignupFormType,
-	UpdateProfileType
+        LoginFormType,
+        ProfileFormType,
+        ResetPassWordFormType,
+        SetPassWordFormType,
+       SignupFormType,
+       UpdateProfileType,
+       EmailFormType
 } from '@/types/formType'
 import type {
 	Prefecture,
@@ -27,7 +28,8 @@ export {
 	ProfileFormType,
 	ResetPassWordFormType,
 	SetPassWordFormType,
-	SignupFormType,
-	SignupResult,
-	UpdateProfileType
+       SignupFormType,
+       SignupResult,
+       UpdateProfileType,
+       EmailFormType
 }


### PR DESCRIPTION
## Summary
- enable editing email via `/profile/email`
- share sidebar navigation links
- add `EmailFormSchema` and types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868cd3cd17483258c77485f6621ebe0